### PR TITLE
Fix hang of ceph tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ before_install:
   - tar -zxf /opt/etcd.tar.gz -C /opt
   - ln -s /opt/etcd-v3.4.13-linux-amd64/etcd /opt/etcd
   - ln -s /opt/etcd-v3.4.13-linux-amd64/etcdctl /opt/etcdctl
+  - export PATH=${PATH}:/opt/
 install:
     # The install requirements in travis virtualenv that will be cached
   - pip install tox-travis .[test,ceph]

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
   - sudo apt-get purge -y postgresql* libpq*
   - sudo rm -rf /var/lib/mysql
   # FIXME(sileht): readd rabbitmq-server when https://github.com/travis-ci/travis-cookbooks/issues/964 and https://github.com/travis-ci/travis-ci/issues/8906 are fixed
-  - sudo apt-get install -y mongodb-server mysql-server redis-server zookeeper mongodb couchdb nodejs npm ceph librados-dev python-dev gcc liberasurecode-dev liberasurecode1 postgresql libpq-dev
+  - sudo apt-get install -y mongodb-server mysql-server redis-server zookeeper mongodb couchdb nodejs npm ceph librados-dev python-dev gcc liberasurecode-dev liberasurecode1 postgresql libpq-dev python3-rados
   # - sudo gem install fakes3  # NOTE(sileht): fakes3 looks not installed correctly
   # - sudo npm install s3rver -g
   - wget https://dl.influxdata.com/influxdb/releases/influxdb_0.13.0_amd64.deb

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ sudo: required
 cache:
   - pip
 python:
-    - 3.6
-    - 3.7
     - 3.8
 before_install:
   # Always redownload tarball

--- a/pifpaf/tests/test_drivers.py
+++ b/pifpaf/tests/test_drivers.py
@@ -372,8 +372,8 @@ class TestDrivers(testtools.TestCase):
         ceph_driver = ceph.CephDriver(tmp_rootdir=tmp_rootdir)
         self.useFixture(ceph_driver)
 
-        ceph_driver._exec(["rados", "-c", os.getenv("CEPH_CONF"), "mkpool",
-                           "gnocchi"]),
+        ceph_driver._exec(["ceph", "-c", os.getenv("CEPH_CONF"), "osd",
+                           "pool", "create", "gnocchi"]),
 
         self.useFixture(gnocchi.GnocchiDriver(
             storage_url="ceph://%s" % os.getenv("CEPH_CONF"),

--- a/tox.ini
+++ b/tox.ini
@@ -13,8 +13,9 @@ deps = .[test,ceph,gnocchi]
        python-swiftclient
        tooz[redis]
 passenv = TMPDIR_FOR_XATTR
+allowlist_externals = env
 commands =
-    stestr run {posargs}
+    env PYTHONPATH={envsitepackagesdir}:/usr/lib/python3/dist-packages/ stestr run {posargs}
 
 [testenv:pep8]
 deps = flake8


### PR DESCRIPTION
It looks like ceph tests hang because 
* mkpool command is removed from rados,
* rados module is missing.

This PR fixes these two problems. 

Along with the changes, this PR fixes two more problems.

The first one is that `keystone` looks like it no more supports Python 3.6 and 3.7 as `pip` fails with this error:
```
Collecting https://tarballs.openstack.org/keystone/keystone-master.tar.gz
  Using cached https://tarballs.openstack.org/keystone/keystone-master.tar.gz (1.7 MB)
ERROR: Package ‘keystone’ requires a different Python: 3.6.12 not in ‘>=3.8’
```
Thus, this PR removes Python 3.6 and 3.7.

The second one is that the CI configuration misses setting `PATH`. Some commands such as `etcd` are installed in `/opt`, but it’s not included in `PATH`. This PR fix this problem, too.